### PR TITLE
add an annotation to the source secret and a failing test that assert…

### DIFF
--- a/pkg/sharing/helpers_for_test.go
+++ b/pkg/sharing/helpers_for_test.go
@@ -29,8 +29,9 @@ func init() {
 func buildSourceSecret() corev1.Secret {
 	return corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-secret",
-			Namespace: "test-source",
+			Name:        "test-secret",
+			Namespace:   "test-source",
+			Annotations: map[string]string{"test-source-annotation": "value"},
 		},
 		Data: map[string][]byte{
 			corev1.DockerConfigJsonKey: []byte(`{"auths":{"server":{"username":"correctUser","password":"correctPassword","auth":"correctAuth"}}}`),

--- a/pkg/sharing/placeholder_secret_test.go
+++ b/pkg/sharing/placeholder_secret_test.go
@@ -6,6 +6,7 @@ package sharing_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -128,6 +129,15 @@ func Test_SecretReconciler_updatesStatus(t *testing.T) {
 
 		reload(t, &placeholderSecret, k8sClient)
 		assert.Equal(t, sourceSecret.Data[".dockerconfigjson"], placeholderSecret.Data[".dockerconfigjson"])
+		assert.Equal(t, sourceSecret.Data[".dockerconfigjson"], placeholderSecret.Data[".dockerconfigjson"])
+		fmt.Println("placeholder Annotations: ", placeholderSecret.ObjectMeta.Annotations)
+		fmt.Println("source Annotations: ", sourceSecret.ObjectMeta.Annotations)
+		for k, v := range sourceSecret.ObjectMeta.Annotations {
+			placeholderV, check := placeholderSecret.ObjectMeta.Annotations[k]
+			assert.True(t, check, fmt.Sprintf("failed to find source key %s in placeholder annotations", k))
+			assert.Equal(t, v, placeholderV)
+		}
+
 		assert.NotNil(t, placeholderSecret.ObjectMeta.Annotations["secretgen.carvel.dev/status"])
 		var observedStatus map[string]interface{}
 		require.NoError(t, json.Unmarshal([]byte(placeholderSecret.ObjectMeta.Annotations["secretgen.carvel.dev/status"]), &observedStatus))


### PR DESCRIPTION
…s it gets copied to the placeholder secret.

This test fails, with output:

```
placeholder Annotations:  map[secretgen.carvel.dev/image-pull-secret: secretgen.carvel.dev/status:{"conditions":[{"type":"ReconcileSucceeded","status":"True"}],"secretNames":["test-source/test-secret"]}]
source Annotations:  map[test-source-annotation:value]
    placeholder_secret_test.go:137:
        	Error Trace:	placeholder_secret_test.go:137
        	Error:      	Should be true
        	Test:       	Test_SecretReconciler_updatesStatus/one_secret_exports_successfully_to_placeholder
        	Messages:   	failed to find source key test-source-annotation in placeholder annotations
    placeholder_secret_test.go:138:
        	Error Trace:	placeholder_secret_test.go:138
        	Error:      	Not equal:
        	            	expected: "value"
        	            	actual  : ""

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-value
        	            	+
        	Test:       	Test_SecretReconciler_updatesStatus/one_secret_exports_successfully_to_placeholder
        	```