### PR TITLE
docs: include `type: Opaque` in secret projection examples

### DIFF
--- a/docs/password.md
+++ b/docs/password.md
@@ -34,6 +34,7 @@ metadata:
 spec:
   length: 124
   secretTemplate:
+    type: Opaque
     stringData:
       postgresql-password: $(value)
 ```

--- a/docs/secret-template.md
+++ b/docs/secret-template.md
@@ -37,6 +37,7 @@ metadata:
   name: pg-password
 spec:
   secretTemplate:
+    type: Opaque
     stringData:
       postgresql-pass: $(value)
 ```
@@ -51,3 +52,5 @@ metadata:
 data:
   postgresql-pass: xxx...
 ```
+
+See [examples](../examples/passwords.yml) for more.


### PR DESCRIPTION
fixes #50 