### PR TITLE
trivy dev branch setup: curl the install script

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -67,7 +67,7 @@ jobs:
           go-version: "1.17"
       - name: Build the secretgen-controller artifacts
         run: |
-          ./hack/install-deps.sh
+          curl -L https://carvel.dev/install.sh | bash
           ./hack/build.sh
 
           # docker image


### PR DESCRIPTION
this pr fixes trivy runs against our develop branch,  results here: https://github.com/vmware-tanzu/carvel-secretgen-controller/actions/runs/2110159104

