### PR TITLE
Controller tools now automatically removes metadata descriptions

### DIFF
--- a/hack/crd-overlay.yml
+++ b/hack/crd-overlay.yml
@@ -9,16 +9,6 @@ metadata:
   #@overlay/remove
   #@overlay/match missing_ok=True
   annotations:
-spec:
-  versions:
-  #@overlay/match by=overlay.all, expects="0+"
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          metadata:
-            #@overlay/remove
-            description:
 #@overlay/remove
 #@overlay/match missing_ok=True
 status:


### PR DESCRIPTION
This overlay currently fails when using vendored controller-tools 0.7.0 because the metadata description has already been removed.

It is no longer generated in CRDs since 0.5.0. See release notes: https://github.com/kubernetes-sigs/controller-tools/releases/tag/v0.5.0

Showing no change in CRD generation:
```sh
git clone git@github.com:Samze/carvel-secretgen-controller.git -b description_fails
Cloning into 'carvel-secretgen-controller'...
remote: Enumerating objects: 17998, done.
remote: Counting objects: 100% (256/256), done.
remote: Compressing objects: 100% (96/96), done.
remote: Total 17998 (delta 199), reused 161 (delta 160), pack-reused 17742
Receiving objects: 100% (17998/17998), 27.14 MiB | 9.96 MiB/s, done.
Resolving deltas: 100% (7215/7215), done.
sgunaratne@sg-dev:/tmp$ cd carvel-secretgen-controller/
sgunaratne@sg-dev:/tmp/carvel-secretgen-controller$ ./hack/gen-crds.sh
sgunaratne@sg-dev:/tmp/carvel-secretgen-controller$ echo $?
0
sgunaratne@sg-dev:/tmp/carvel-secretgen-controller$ git diff
sgunaratne@sg-dev:/tmp/carvel-secretgen-controller$
```