### PR TITLE
SecretTemplate watches for Secret InputResources

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vmware-tanzu/carvel-secretgen-controller/pkg/generator"
 	"github.com/vmware-tanzu/carvel-secretgen-controller/pkg/satoken"
 	"github.com/vmware-tanzu/carvel-secretgen-controller/pkg/sharing"
+	"github.com/vmware-tanzu/carvel-secretgen-controller/pkg/tracker"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -76,7 +77,7 @@ func main() {
 	exitIfErr(entryLog, "registering", registerCtrl("sshkey", mgr, sshKeyReconciler))
 
 	saLoader := generator.NewServiceAccountLoader(satoken.NewManager(coreClient, log.WithName("template")))
-	secretTemplateReconciler := generator.NewSecretTemplateReconciler(mgr.GetClient(), saLoader, log.WithName("template"))
+	secretTemplateReconciler := generator.NewSecretTemplateReconciler(mgr.GetClient(), saLoader, tracker.NewTracker(), log.WithName("template"))
 	exitIfErr(entryLog, "registering", registerCtrl("template", mgr, secretTemplateReconciler))
 
 	{

--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -1,0 +1,58 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracker
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Tracker allows "tracking" resources to monitor "tracked" resources.
+// All "tracking" resources can then be found for a given "tracked" resource.
+// Tracker is thread-safe.
+type Tracker struct {
+	// Holds a set of resources(tracking) to set of resources(tracked)
+	tracker map[types.NamespacedName]map[types.NamespacedName]struct{}
+	mu      sync.RWMutex
+}
+
+// NewTracker creates a new Tracker
+func NewTracker() *Tracker {
+	return &Tracker{tracker: map[types.NamespacedName]map[types.NamespacedName]struct{}{}}
+}
+
+// Track records that the tracking object is interested in all tracked objects
+func (s *Tracker) Track(tracking types.NamespacedName, tracked ...types.NamespacedName) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	set, found := s.tracker[tracking]
+	if !found {
+		set = map[types.NamespacedName]struct{}{}
+		s.tracker[tracking] = set
+	}
+	for _, t := range tracked {
+		set[t] = struct{}{}
+	}
+}
+
+// UntrackAll untracks all tracking objects. This method is idempotent
+func (s *Tracker) UntrackAll(tracking types.NamespacedName) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.tracker, tracking)
+}
+
+// GetTracking returns all tracking objects for a given tracked object
+func (s *Tracker) GetTracking(tracked types.NamespacedName) []types.NamespacedName {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	trackingList := []types.NamespacedName{}
+	for tracking, trackedSet := range s.tracker {
+		if _, found := trackedSet[tracked]; found {
+			trackingList = append(trackingList, tracking)
+		}
+	}
+	return trackingList
+}

--- a/pkg/tracker/tracker_test.go
+++ b/pkg/tracker/tracker_test.go
@@ -1,0 +1,43 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tracker_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/carvel-secretgen-controller/pkg/tracker"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func Test_Tracker(t *testing.T) {
+
+	t.Run("Test tracker", func(t *testing.T) {
+		tracking1 := types.NamespacedName{Namespace: "ns1", Name: "tracking"}
+		tracking2 := types.NamespacedName{Namespace: "ns2", Name: "tracking"}
+		tracked1 := types.NamespacedName{Namespace: "ns3", Name: "tracked"}
+		tracked2 := types.NamespacedName{Namespace: "ns4", Name: "tracked"}
+		neverTracked := types.NamespacedName{Namespace: "ns4", Name: "nevertracked"}
+
+		tracker := tracker.NewTracker()
+
+		assert.Len(t, tracker.GetTracking(tracked1), 0, "should be zero tracking")
+		assert.Len(t, tracker.GetTracking(tracked2), 0, "should be zero tracking")
+
+		tracker.Track(tracking1, tracked1, tracked2)
+		tracker.Track(tracking2, tracked1)
+
+		assert.ElementsMatch(t, tracker.GetTracking(tracked1), []types.NamespacedName{tracking1, tracking2}, "did not contain both tracking resources")
+		assert.ElementsMatch(t, tracker.GetTracking(tracked2), []types.NamespacedName{tracking1}, "did not contain tracking resource")
+
+		assert.Len(t, tracker.GetTracking(neverTracked), 0, "should be zero tracking")
+
+		tracker.UntrackAll(tracking1)
+		assert.ElementsMatch(t, tracker.GetTracking(tracked1), []types.NamespacedName{tracking2}, "did not contain tracking resource")
+		assert.Len(t, tracker.GetTracking(tracked2), 0, "should be zero tracking")
+
+		tracker.UntrackAll(tracking2)
+		assert.Len(t, tracker.GetTracking(tracked1), 0, "should be zero tracking")
+	})
+}


### PR DESCRIPTION
This introduces a watch mechanism for SecretTemplate when no service
account is specified, so for this case we can remove the periodic
re-sync - improving performance.

We still need a periodic resync for non-secret resources because we
use a user configurable service account for these resources.
Therefore we cannot use a single watch or shared informer and setting
up watches per secret template service account per GVR is too expensive.

Implementation notes:
- As mentioned only support watch when Service Account is not specified
- Rely on an internal tracker that can be referred when a secret event
in generated. This tracker allows a SecretTemplate to track N Secrets.
And for a given Secret, allows you to receive all interested
SecretTemplates.
- When a SecretTemplate is deleted we use 404 to clear the tracking
 information. Even if we don't receive a reconcile immediately, if an
    input resource changes, we will receive a notfication for the missing
    SecretTemplate and then clear tracking that way.
- Tracker currently doesn't understand GVKs, right now this is not needed.

closes #68 