### PR TITLE
Check if annotations are empty before setting them

### DIFF
--- a/pkg/generator/certificate_reconciler.go
+++ b/pkg/generator/certificate_reconciler.go
@@ -116,7 +116,10 @@ func (r *CertificateReconciler) createSecret(ctx context.Context, params certPar
 
 	newSecret := secret.AsSecret()
 
-	GenerateInputs{params}.Add(newSecret.Annotations)
+	err = GenerateInputs{params}.Add(newSecret.Annotations)
+	if err != nil {
+		return reconcile.Result{Requeue: true}, err
+	}
 
 	_, err = r.coreClient.CoreV1().Secrets(newSecret.Namespace).Create(ctx, newSecret, metav1.CreateOptions{})
 	if err != nil {

--- a/pkg/generator/certificate_reconciler.go
+++ b/pkg/generator/certificate_reconciler.go
@@ -116,6 +116,11 @@ func (r *CertificateReconciler) createSecret(ctx context.Context, params certPar
 
 	newSecret := secret.AsSecret()
 
+	if newSecret.Annotations == nil {
+		newSecret.Annotations = map[string]string{
+			"secretgen.k14s.io/generate-inputs": "",
+		}
+	}
 	err = GenerateInputs{params}.Add(newSecret.Annotations)
 	if err != nil {
 		return reconcile.Result{Requeue: true}, err

--- a/pkg/generator/certificate_reconciler.go
+++ b/pkg/generator/certificate_reconciler.go
@@ -117,9 +117,7 @@ func (r *CertificateReconciler) createSecret(ctx context.Context, params certPar
 	newSecret := secret.AsSecret()
 
 	if newSecret.Annotations == nil {
-		newSecret.Annotations = map[string]string{
-			"secretgen.k14s.io/generate-inputs": "",
-		}
+		newSecret.Annotations = map[string]string{}
 	}
 	err = GenerateInputs{params}.Add(newSecret.Annotations)
 	if err != nil {

--- a/pkg/generator/generate_inputs.go
+++ b/pkg/generator/generate_inputs.go
@@ -6,7 +6,6 @@ package generator
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 )
 
 const (
@@ -23,7 +22,6 @@ func (i GenerateInputs) Add(anns map[string]string) error {
 			"secretgen.k14s.io/generate-inputs": "",
 		}
 	}
-	fmt.Println(anns)
 	bs, err := json.Marshal(i.inputs)
 	if err != nil {
 		return errors.New("cannot marshal generate inputs")

--- a/pkg/generator/generate_inputs.go
+++ b/pkg/generator/generate_inputs.go
@@ -16,6 +16,8 @@ type GenerateInputs struct {
 	inputs interface{}
 }
 
+// Add adds the metadata annotations from the certificate to the secret annotations map,
+// specifically as JSON string in the GenerateInputsAnnKey key
 func (i GenerateInputs) Add(anns map[string]string) error {
 	if anns == nil {
 		return errors.New("internal inconsistency: called with annotations nil param")

--- a/pkg/generator/generate_inputs.go
+++ b/pkg/generator/generate_inputs.go
@@ -5,6 +5,8 @@ package generator
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 )
 
 const (
@@ -15,14 +17,19 @@ type GenerateInputs struct {
 	inputs interface{}
 }
 
-func (i GenerateInputs) Add(anns map[string]string) {
-	if len(anns) > 0 {
-		bs, err := json.Marshal(i.inputs)
-		if err != nil {
-			panic("Cannot marshal generate inputs")
+func (i GenerateInputs) Add(anns map[string]string) error {
+	if len(anns) == 0 {
+		anns = map[string]string{
+			"secretgen.k14s.io/generate-inputs": "",
 		}
-		anns[GenerateInputsAnnKey] = string(bs)
 	}
+	fmt.Println(anns)
+	bs, err := json.Marshal(i.inputs)
+	if err != nil {
+		return errors.New("cannot marshal generate inputs")
+	}
+	anns[GenerateInputsAnnKey] = string(bs)
+	return nil
 }
 
 func (i GenerateInputs) IsChanged(anns map[string]string) bool {

--- a/pkg/generator/generate_inputs.go
+++ b/pkg/generator/generate_inputs.go
@@ -17,10 +17,8 @@ type GenerateInputs struct {
 }
 
 func (i GenerateInputs) Add(anns map[string]string) error {
-	if len(anns) == 0 {
-		anns = map[string]string{
-			"secretgen.k14s.io/generate-inputs": "",
-		}
+	if anns == nil {
+		return errors.New("internal inconsistency: called with annotations nil param")
 	}
 	bs, err := json.Marshal(i.inputs)
 	if err != nil {

--- a/pkg/generator/generate_inputs.go
+++ b/pkg/generator/generate_inputs.go
@@ -16,11 +16,13 @@ type GenerateInputs struct {
 }
 
 func (i GenerateInputs) Add(anns map[string]string) {
-	bs, err := json.Marshal(i.inputs)
-	if err != nil {
-		panic("Cannot marshal generate inputs")
+	if len(anns) > 0 {
+		bs, err := json.Marshal(i.inputs)
+		if err != nil {
+			panic("Cannot marshal generate inputs")
+		}
+		anns[GenerateInputsAnnKey] = string(bs)
 	}
-	anns[GenerateInputsAnnKey] = string(bs)
 }
 
 func (i GenerateInputs) IsChanged(anns map[string]string) bool {

--- a/pkg/generator/generate_inputs_test.go
+++ b/pkg/generator/generate_inputs_test.go
@@ -4,18 +4,19 @@
 package generator_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware-tanzu/carvel-secretgen-controller/pkg/generator"
 )
 
-func TestAddSucceedsWithEmptyAnnotations(t *testing.T) {
+func TestAddFailsWithEmptyAnnotations(t *testing.T) {
 	err := generator.GenerateInputs{}.Add(nil)
-	assert.Equal(t, nil, err)
+	assert.Equal(t, errors.New("internal inconsistency: called with annotations nil param"), err)
 }
 
-func TestAddSuccessfulWithDefaultAnnotation(t *testing.T) {
+func TestAddSucceedsfulWithDefaultAnnotation(t *testing.T) {
 	defaultAnnotations := map[string]string{
 		"secretgen.k14s.io/generate-inputs": "",
 	}

--- a/pkg/generator/generate_inputs_test.go
+++ b/pkg/generator/generate_inputs_test.go
@@ -20,5 +20,5 @@ func TestAddSuccessfulWithDefaultAnnotation(t *testing.T) {
 		"secretgen.k14s.io/generate-inputs": "",
 	}
 	err := generator.GenerateInputs{}.Add(defaultAnnotations)
-	assert.Equal(t, err, nil)
+	assert.Equal(t, nil, err)
 }

--- a/pkg/generator/generate_inputs_test.go
+++ b/pkg/generator/generate_inputs_test.go
@@ -1,0 +1,24 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package generator_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/carvel-secretgen-controller/pkg/generator"
+)
+
+func TestAddSucceedsWithEmptyAnnotations(t *testing.T) {
+	err := generator.GenerateInputs{}.Add(nil)
+	assert.Equal(t, nil, err)
+}
+
+func TestAddSuccessfulWithDefaultAnnotation(t *testing.T) {
+	defaultAnnotations := map[string]string{
+		"secretgen.k14s.io/generate-inputs": "",
+	}
+	err := generator.GenerateInputs{}.Add(defaultAnnotations)
+	assert.Equal(t, err, nil)
+}

--- a/test/e2e/certificate_test.go
+++ b/test/e2e/certificate_test.go
@@ -87,6 +87,9 @@ spec:
 		if len(secret.Data["key.pem"]) == 0 {
 			t.Fatalf("Failed to find app2-cert key.pem")
 		}
+		if len(secret.Annotations) == 0 {
+			t.Fatalf("Failed to find annotations")
+		}
 		// TODO more cert checking
 	})
 


### PR DESCRIPTION
Fixes #84 

When the secret we want to create does not have annotations, the map object received by GenerateInputs.Add is empty. To be able to process certificates with or without annotations, we check the length of the map before marshalling it.

Signed-off-by: Víctor Martínez Bevià <vicmarbev@gmail.com>