### PR TITLE
Do not set seccompProfile in v0.13.x

### DIFF
--- a/config/package-bundle/config/deployment.yml
+++ b/config/package-bundle/config/deployment.yml
@@ -41,7 +41,5 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
       #@ if/end data.values.deployment.nodeSelector != None:
       nodeSelector: #@ data.values.deployment.nodeSelector


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/CONTRIBUTING.md and developer guide https://github.com/vmware-tanzu/carvel-kapp-controller/blob/develop/docs/dev.md
-->

#### What this PR does / why we need it:
Do not set seccompProfile
Setting seccompProfile violates the policies set by default SCCs in older versions of Openshift

#### Tests
- Tested on Openshift 4.10
- Tested on Openshift 4.11 (There's a warning to set seccompProfile but the default SCCs set it to RuntimeDefault for all pods)
