### PR TITLE
Bump Golang to 1.19.4

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.3"
+          go-version: "1.19.4"
       - uses: actions/checkout@v3.0.1
         with:
           fetch-depth: '0'

--- a/.github/workflows/kind-action.yml
+++ b/.github/workflows/kind-action.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3 # default version of go is 1.10
         with:
-          go-version: "1.19.3"
+          go-version: "1.19.4"
       - name: Install Carvel Tools
         uses: vmware-tanzu/carvel-setup-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.3
+          go-version: 1.19.4
       - name: Install Carvel Tools
         uses: vmware-tanzu/carvel-setup-action@v1
         with:

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: "1.19.3"
+        go-version: "1.19.4"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.3"
+          go-version: "1.19.4"
       - name: Build the secretgen-controller artifacts
         run: |
           curl -L https://carvel.dev/install.sh | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.3 AS deps
+FROM --platform=$BUILDPLATFORM golang:1.19.4 AS deps
 
 ARG TARGETOS TARGETARCH SGCTRL_VER=development
 WORKDIR /workspace


### PR DESCRIPTION
Bumping Golang for [CVE-2022-41720](https://osspi.eng.vmware.com/api/v3/vulnerabilities/CVE-2022-41720/overview/)