### PR TITLE
Bump go version to 1.20.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,5 +28,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.51.2
           args: -v

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.5"
+          go-version: "1.20.1"
       - uses: actions/checkout@v3.0.1
         with:
           fetch-depth: '0'

--- a/.github/workflows/kind-action.yml
+++ b/.github/workflows/kind-action.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3 # default version of go is 1.10
         with:
-          go-version: "1.19.5"
+          go-version: "1.20.1"
       - name: Install Carvel Tools
         uses: carvel-dev/setup-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.5
+          go-version: 1.20.1
       - name: Install Carvel Tools
         uses: carvel-dev/carvel-setup-action@v1
         with:

--- a/.github/workflows/test-gh.yml
+++ b/.github/workflows/test-gh.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: "1.19.5"
+        go-version: "1.20.1"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19.5"
+          go-version: "1.20.1"
       - name: Build the secretgen-controller artifacts
         run: |
           curl -L https://carvel.dev/install.sh | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.5 AS deps
+FROM --platform=$BUILDPLATFORM golang:1.20.1 AS deps
 
 ARG TARGETOS TARGETARCH SGCTRL_VER=development
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/carvel-secretgen-controller
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cloudfoundry/bosh-utils v0.0.354 // indirect


### PR DESCRIPTION
- Bump go version to 1.20.1
- Bump golangci-lint to 1.51.2 as go 1.20 support was added from 1.51.0 onwards