### PR TITLE
Changing the carvel-setup-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1.19.5
       - name: Install Carvel Tools
-        uses: carvel-dev/carvel-setup-action@v1
+        uses: carvel-dev/setup-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           only: ytt, kapp, kbld, imgpkg, kctrl, vendir


### PR DESCRIPTION
After the migration from vmware-tanzu, setup-action has been renamed from `vmware-tanzu/carvel-setup-action@v1` to `carvel-dev/setup-action@v1`