### PR TITLE
Bumping emicklei go restful to v3.10.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/emicklei/go-restful/v3 v3.10.2 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
-github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emicklei/go-restful/v3 v3.10.2 h1:hIovbnmBTLjHXkqEBUz3HGpXZdM7ZrE9fJIZIqlJLqE=
+github.com/emicklei/go-restful/v3 v3.10.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/vendor/github.com/emicklei/go-restful/v3/CHANGES.md
+++ b/vendor/github.com/emicklei/go-restful/v3/CHANGES.md
@@ -1,10 +1,26 @@
 # Change history of go-restful
 
-## [v3.9.0] - 20221-07-21
+## [v3.10.2] - 2023-03-09
+
+- introduced MergePathStrategy to be able to revert behaviour of path concatenation to 3.9.0
+  see comment in Readme how to customize this behaviour.
+
+## [v3.10.1] - 2022-11-19
+
+- fix broken 3.10.0 by using path package for joining paths
+
+## [v3.10.0] - 2022-10-11 - BROKEN
+
+- changed tokenizer to match std route match behavior; do not trimright the path (#511)
+- Add MIME_ZIP (#512)
+- Add MIME_ZIP and HEADER_ContentDisposition (#513)
+- Changed how to get query parameter issue #510
+
+## [v3.9.0] - 2022-07-21
 
 - add support for http.Handler implementations to work as FilterFunction, issue #504 (thanks to https://github.com/ggicci)
 
-## [v3.8.0] - 20221-06-06
+## [v3.8.0] - 2022-06-06
 
 - use exact matching of allowed domain entries, issue #489 (#493)
 	- this changes fixes [security] Authorization Bypass Through User-Controlled Key

--- a/vendor/github.com/emicklei/go-restful/v3/README.md
+++ b/vendor/github.com/emicklei/go-restful/v3/README.md
@@ -96,6 +96,10 @@ There are several hooks to customize the behavior of the go-restful package.
 - Compression
 - Encoders for other serializers
 - Use [jsoniter](https://github.com/json-iterator/go) by building this package using a build tag, e.g. `go build -tags=jsoniter .` 
+- Use the variable `MergePathStrategy` to change the behaviour of composing the Route path given a root path and a local route path	
+	- versions >= 3.10.1 has set the value to `PathJoinStrategy` that fixes a reported [security issue](https://github.com/advisories/GHSA-r48q-9g5r-8q2h) but may cause your services not to work correctly anymore.
+	- versions <= 3.9 had the behaviour that can be restored in newer versions by setting the value to `TrimSlashStrategy`.
+	- you can set value to a custom implementation (must implement MergePathStrategyFunc)
 
 ## Resources
 

--- a/vendor/github.com/emicklei/go-restful/v3/constants.go
+++ b/vendor/github.com/emicklei/go-restful/v3/constants.go
@@ -7,12 +7,14 @@ package restful
 const (
 	MIME_XML   = "application/xml"          // Accept or Content-Type used in Consumes() and/or Produces()
 	MIME_JSON  = "application/json"         // Accept or Content-Type used in Consumes() and/or Produces()
+	MIME_ZIP   = "application/zip"          // Accept or Content-Type used in Consumes() and/or Produces()
 	MIME_OCTET = "application/octet-stream" // If Content-Type is not present in request, use the default
 
 	HEADER_Allow                         = "Allow"
 	HEADER_Accept                        = "Accept"
 	HEADER_Origin                        = "Origin"
 	HEADER_ContentType                   = "Content-Type"
+	HEADER_ContentDisposition            = "Content-Disposition"
 	HEADER_LastModified                  = "Last-Modified"
 	HEADER_AcceptEncoding                = "Accept-Encoding"
 	HEADER_ContentEncoding               = "Content-Encoding"

--- a/vendor/github.com/emicklei/go-restful/v3/request.go
+++ b/vendor/github.com/emicklei/go-restful/v3/request.go
@@ -31,7 +31,8 @@ func NewRequest(httpRequest *http.Request) *Request {
 // a "Unable to unmarshal content of type:" response is returned.
 // Valid values are restful.MIME_JSON and restful.MIME_XML
 // Example:
-// 	restful.DefaultRequestContentType(restful.MIME_JSON)
+//
+//	restful.DefaultRequestContentType(restful.MIME_JSON)
 func DefaultRequestContentType(mime string) {
 	defaultRequestContentType = mime
 }
@@ -48,7 +49,7 @@ func (r *Request) PathParameters() map[string]string {
 
 // QueryParameter returns the (first) Query parameter value by its name
 func (r *Request) QueryParameter(name string) string {
-	return r.Request.FormValue(name)
+	return r.Request.URL.Query().Get(name)
 }
 
 // QueryParameters returns the all the query parameters values by name

--- a/vendor/github.com/emicklei/go-restful/v3/response.go
+++ b/vendor/github.com/emicklei/go-restful/v3/response.go
@@ -109,6 +109,9 @@ func (r *Response) EntityWriter() (EntityReaderWriter, bool) {
 		if DefaultResponseMimeType == MIME_XML {
 			return entityAccessRegistry.accessorAt(MIME_XML)
 		}
+		if DefaultResponseMimeType == MIME_ZIP {
+			return entityAccessRegistry.accessorAt(MIME_ZIP)
+		}
 		// Fallback to whatever the route says it can produce.
 		// https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
 		for _, each := range r.routeProduces {

--- a/vendor/github.com/emicklei/go-restful/v3/route.go
+++ b/vendor/github.com/emicklei/go-restful/v3/route.go
@@ -164,7 +164,7 @@ func tokenizePath(path string) []string {
 	if "/" == path {
 		return nil
 	}
-	return strings.Split(strings.Trim(path, "/"), "/")
+	return strings.Split(strings.TrimLeft(path, "/"), "/")
 }
 
 // for debugging
@@ -176,3 +176,5 @@ func (r *Route) String() string {
 func (r *Route) EnableContentEncoding(enabled bool) {
 	r.contentEncodingEnabled = &enabled
 }
+
+var TrimRightSlashEnabled = false

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/cloudfoundry/config-server/types
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/emicklei/go-restful/v3 v3.9.0
+# github.com/emicklei/go-restful/v3 v3.10.2
 ## explicit; go 1.13
 github.com/emicklei/go-restful/v3
 github.com/emicklei/go-restful/v3/log


### PR DESCRIPTION
- Bumping go-restful as requested by one of the users in Slack tread as they are getting `PRISMA-2022-0227` CVE