### PR TITLE
Make metrics server port configurable

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -37,12 +37,14 @@ var (
 	// Version of secretgen-controller is set via ldflags at build-time from most recent git tag
 	Version = "develop"
 
-	log           = logf.Log.WithName("sg")
-	ctrlNamespace = ""
+	log                = logf.Log.WithName("sg")
+	ctrlNamespace      = ""
+	metricsBindAddress = ""
 )
 
 func main() {
 	flag.StringVar(&ctrlNamespace, "namespace", "", "Namespace to watch")
+	flag.StringVar(&metricsBindAddress, "metrics-bind-address", ":8080", "Address for metrics server. If 0, then metrics server doesnt listen on any port.")
 	flag.Parse()
 
 	logf.SetLogger(zap.New(zap.UseDevMode(false)))
@@ -56,7 +58,7 @@ func main() {
 	sgv1alpha1.AddToScheme(scheme.Scheme)
 	sg2v1alpha1.AddToScheme(scheme.Scheme)
 
-	mgr, err := manager.New(restConfig, manager.Options{Namespace: ctrlNamespace})
+	mgr, err := manager.New(restConfig, manager.Options{Namespace: ctrlNamespace, MetricsBindAddress: metricsBindAddress})
 	exitIfErr(entryLog, "unable to set up controller manager", err)
 
 	entryLog.Info("setting up controllers")


### PR DESCRIPTION
Adds a flag to the controller to support configuring a non-default port for the metrics collection.

This resolves an issue where running secretgen-controller with `hostNetwork=true` may lead to port conflicts on the node.

Fixes #509 

## Testing Done:
 - Built and ensured passing unit tests locally
 - Deployed in a Kind cluster and loaded Docker image onto cluster
 - Edited Deployment to add new container arg: `-metrics-bind-address=:8093`
 - Confirmed new secretgen-controller Pod logged the change: 
```
...
{"level":"info","ts":"2023-12-07T21:19:22Z","logger":"controller-runtime.metrics","msg":"Metrics server is starting to listen","addr":":8093"}
{"level":"info","ts":"2023-12-07T21:19:22Z","logger":"sg.entrypoint","msg":"setting up controllers"}
{"level":"info","ts":"2023-12-07T21:19:22Z","logger":"sg.entrypoint","msg":"starting manager"}
{"level":"info","ts":"2023-12-07T21:19:22Z","msg":"Starting server","path":"/metrics","kind":"metrics","addr":"[::]:8093"}
...
```