### PR TITLE
Set seccompProfile to RuntimeDefault for secretgen-controller container

### DIFF
--- a/config/package-bundle/config/deployment.yml
+++ b/config/package-bundle/config/deployment.yml
@@ -41,5 +41,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          seccompProfile:
+            type: RuntimeDefault
       #@ if/end data.values.deployment.nodeSelector != None:
       nodeSelector: #@ data.values.deployment.nodeSelector


### PR DESCRIPTION
#### What this PR does / why we need it:
Set seccompProfile to RuntimeDefault for kapp-controller and kapp-controller-sidecarexec containers

#### Which issue(s) this PR fixes:

Fixes #519 