### PR TITLE
Skip merging docker config with no auth data

### DIFF
--- a/pkg/sharing/dockerconfigjson.go
+++ b/pkg/sharing/dockerconfigjson.go
@@ -43,6 +43,10 @@ func NewCombinedDockerConfigJSON(secrets []*corev1.Secret) (map[string][]byte, e
 
 		// TODO should we have more complex merging here?
 		for server, auth := range auths.Auths {
+			// Skip entries that have no auth data
+			if auth.Username == "" && auth.Password == "" && auth.Auth == "" {
+				continue
+			}
 			combined.Auths[server] = auth
 		}
 	}

--- a/pkg/sharing/dockerconfigjson_test.go
+++ b/pkg/sharing/dockerconfigjson_test.go
@@ -63,4 +63,28 @@ func Test_NewCombinedDockerConfigJSON(t *testing.T) {
 		assert.Equal(t, 1, len(result))
 		assert.Equal(t, expected, result[corev1.DockerConfigJsonKey])
 	})
+
+	t.Run("skips entries with no auth data", func(t *testing.T) {
+		// Secret with 1 valid and 1 empty auths
+		secrets := []*corev1.Secret{
+			&corev1.Secret{
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: []byte(`{"auths":{"valid-server1":{"username":"user1","password":"pass1","auth":"auth1"},"empty-server1":{"username":"","password":"","auth":""}}}`),
+				},
+			},
+			// Another Secret with 1 valid and 1 empty auths
+			&corev1.Secret{
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: []byte(`{"auths":{"valid-server2":{"username":"user2","password":"pass2","auth":"auth2"},"empty-server2":{"username":"","password":"","auth":""}}}`),
+				},
+			},
+		}
+		result, err := NewCombinedDockerConfigJSON(secrets)
+		require.NoError(t, err)
+
+		// Expected result should have only the valid auths
+		expected := []byte(`{"auths":{"valid-server1":{"username":"user1","password":"pass1","auth":"auth1"},"valid-server2":{"username":"user2","password":"pass2","auth":"auth2"}}}`)
+		assert.Equal(t, 1, len(result))
+		assert.Equal(t, expected, result[corev1.DockerConfigJsonKey])
+	})
 }


### PR DESCRIPTION
Fixes issue #710 

## PR Description:
When the registry does not require credentials, the source dockerconfigjson contains only the registry entry + certs, but no auth fields.

secretgen-controller merges this and produces e.g.

```
{
  "auths": {
    "harbor.internal": {
      "username": "",
      "password": "",
      "auth": ""
    }
  }
}
```

This is incorrect because the auths field is not empty, but the username, password, and auth fields are empty.
Kapp-controller then uses this placeholder secret for package/image fetching, registry rejects it with:
`Unsupported Auth config`

This PR updates the dockerconfigjson merge logic to skip registry entries that have no credentials, preventing sgc from generating invalid empty auth blocks that cause `Unsupported Auth config` errors with registry