### PR TITLE
Bump golang to 1.25.5 to fix CVEs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,5 +28,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64
+          version: v2.4
           args: -v

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.4
           args: -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: "2"
 run:
   timeout: 5m
 linters:
@@ -5,16 +6,13 @@ linters:
     - goheader
     - revive
     - unused
-  disable-all: true
-# all available settings of specific linters
-linters-settings:
-  goheader:
-    values:
-      regexp:
-        copyright-year: 20[0-9][0-9]
-    template-path: code-header-template.txt
+  settings:
+    goheader:
+      values:
+        regexp:
+          copyright-year: 20[0-9][0-9]
+      template-path: code-header-template.txt
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude-use-default: false
   new-from-rev: ae7b7b79a75756ae3cec92e8bb8c6bf0c4dab48e

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24.10 AS deps
+FROM --platform=$BUILDPLATFORM golang:1.25.5 AS deps
 
 ARG TARGETOS TARGETARCH SGCTRL_VER=development
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module carvel.dev/secretgen-controller
 
-go 1.24.10
+go 1.25.5
 
 require (
 	github.com/cloudfoundry/bosh-utils v0.0.563 // indirect

--- a/pkg/apis/secretgen2/v1alpha1/secret_export.go
+++ b/pkg/apis/secretgen2/v1alpha1/secret_export.go
@@ -45,9 +45,9 @@ type SelectorOperator string
 // SelectorOperator values
 const (
 	SelectorOperatorIn           SelectorOperator = "In"
-	SelectorOperatorNotIn                         = "NotIn"
-	SelectorOperatorExists                        = "Exists"
-	SelectorOperatorDoesNotExist                  = "DoesNotExist"
+	SelectorOperatorNotIn        SelectorOperator = "NotIn"
+	SelectorOperatorExists       SelectorOperator = "Exists"
+	SelectorOperatorDoesNotExist SelectorOperator = "DoesNotExist"
 )
 
 // SelectorMatchField is a selector field to match against namespace definition
@@ -91,22 +91,22 @@ func (e SecretExport) Validate() error {
 	toSmf := e.Spec.ToNamespacesSelector
 
 	if len(toNses) == 0 && len(toSmf) == 0 {
-		errs = append(errs, fmt.Errorf("Expected to have at least one non-empty to namespace or to namespace annotation"))
+		errs = append(errs, fmt.Errorf("expected to have at least one non-empty to namespace or to namespace annotation"))
 	}
 	for _, ns := range toNses {
 		if len(ns) == 0 {
-			errs = append(errs, fmt.Errorf("Expected to namespace to be non-empty"))
+			errs = append(errs, fmt.Errorf("expected to namespace to be non-empty"))
 		}
 	}
 	for _, s := range toSmf {
 		switch s.Operator {
 		case SelectorOperatorIn, SelectorOperatorNotIn:
 			if len(s.Values) == 0 {
-				errs = append(errs, fmt.Errorf("Values must be specified when `operator` is 'In' or 'NotIn'"))
+				errs = append(errs, fmt.Errorf("values must be specified when `operator` is 'In' or 'NotIn'"))
 			}
 		case SelectorOperatorExists, SelectorOperatorDoesNotExist:
 			if len(s.Values) > 0 {
-				errs = append(errs, fmt.Errorf("Values may not be specified when `operator` is 'Exists' or 'DoesNotExist'"))
+				errs = append(errs, fmt.Errorf("values may not be specified when `operator` is 'Exists' or 'DoesNotExist'"))
 			}
 		}
 	}

--- a/pkg/generator/secret_template_reconciler.go
+++ b/pkg/generator/secret_template_reconciler.go
@@ -116,7 +116,7 @@ func (r *SecretTemplateReconciler) Reconcile(ctx context.Context, request reconc
 	}
 
 	status.SetReconciling(secretTemplate.ObjectMeta)
-	defer r.updateStatus(ctx, &secretTemplate)
+	defer func() { _ = r.updateStatus(ctx, &secretTemplate) }()
 
 	return status.WithReconcileCompleted(r.reconcile(ctx, &secretTemplate))
 }
@@ -144,8 +144,8 @@ func (r *SecretTemplateReconciler) reconcile(ctx context.Context, secretTemplate
 	if _, err = controllerutil.CreateOrUpdate(ctx, r.client, &secret, func() error {
 		secret.Data = evaluatedTemplateSecret.Data
 		secret.StringData = evaluatedTemplateSecret.StringData
-		secret.ObjectMeta.Annotations = evaluatedTemplateSecret.Annotations
-		secret.ObjectMeta.Labels = evaluatedTemplateSecret.Labels
+		secret.Annotations = evaluatedTemplateSecret.Annotations
+		secret.Labels = evaluatedTemplateSecret.Labels
 
 		// Secret Type is immutable, so cannot be updated. TODO what to do here?
 		secret.Type = evaluatedTemplateSecret.Type

--- a/pkg/generator/secret_template_test.go
+++ b/pkg/generator/secret_template_test.go
@@ -780,8 +780,12 @@ func configMap(name string, data map[string]string) *corev1.ConfigMap {
 }
 
 func newReconciler(objects ...client.Object) (secretTemplateReconciler *generator.SecretTemplateReconciler, k8sClient client.Client) {
-	sg2v1alpha1.AddToScheme(scheme.Scheme)
-	corev1.AddToScheme(scheme.Scheme)
+	if err := sg2v1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		panic(err)
+	}
+	if err := corev1.AddToScheme(scheme.Scheme); err != nil {
+		panic(err)
+	}
 	testLogr := zap.New(zap.UseDevMode(true))
 	k8sClient = fakeClient.NewClientBuilder().WithObjects(objects...).WithScheme(scheme.Scheme).Build()
 

--- a/pkg/satoken/token_manager.go
+++ b/pkg/satoken/token_manager.go
@@ -85,11 +85,11 @@ func (m *Manager) GetServiceAccountToken(ctx context.Context, namespace, name st
 	if err != nil {
 		switch {
 		case !ok:
-			return nil, fmt.Errorf("Fetch token: %v", err)
+			return nil, fmt.Errorf("fetch token: %v", err)
 		case m.expired(ctr):
-			return nil, fmt.Errorf("Token %s expired and refresh failed: %v", key, err)
+			return nil, fmt.Errorf("token %s expired and refresh failed: %v", key, err)
 		default:
-			m.log.Error(err, "Update token", "cacheKey", key)
+			m.log.Error(err, "update token", "cacheKey", key)
 			return ctr, nil
 		}
 	}

--- a/pkg/sharing/helpers_for_test.go
+++ b/pkg/sharing/helpers_for_test.go
@@ -22,7 +22,9 @@ import (
 var testLogr logr.Logger
 
 func init() {
-	sg2v1alpha1.AddToScheme(scheme.Scheme)
+	if err := sg2v1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		panic(err)
+	}
 	testLogr = zap.New(zap.UseDevMode(true))
 }
 

--- a/pkg/sharing/import_secret_test.go
+++ b/pkg/sharing/import_secret_test.go
@@ -68,7 +68,7 @@ func secretImportFor(sourceSecret corev1.Secret) sg2v1alpha1.SecretImport {
 }
 
 func importReconcilers(objects ...runtime.Object) (secretExportReconciler *sharing.SecretExportReconciler, secretImportReconciler *sharing.SecretImportReconciler, k8sClient client.Client) {
-	k8sClient = fakeClient.NewFakeClient(objects...)
+	k8sClient = fakeClient.NewClientBuilder().WithRuntimeObjects(objects...).Build()
 	secretExports := sharing.NewSecretExportsWarmedUp(sharing.NewSecretExports(k8sClient, testLogr))
 	secretExportReconciler = sharing.NewSecretExportReconciler(k8sClient, secretExports, testLogr)
 	secretExports.WarmUpFunc = secretExportReconciler.WarmUp

--- a/pkg/sharing/placeholder_secret_test.go
+++ b/pkg/sharing/placeholder_secret_test.go
@@ -128,9 +128,9 @@ func Test_SecretReconciler_updatesStatus(t *testing.T) {
 
 		reload(t, &placeholderSecret, k8sClient)
 		assert.Equal(t, sourceSecret.Data[".dockerconfigjson"], placeholderSecret.Data[".dockerconfigjson"])
-		assert.NotNil(t, placeholderSecret.ObjectMeta.Annotations["secretgen.carvel.dev/status"])
+		assert.NotNil(t, placeholderSecret.Annotations["secretgen.carvel.dev/status"])
 		var observedStatus map[string]interface{}
-		require.NoError(t, json.Unmarshal([]byte(placeholderSecret.ObjectMeta.Annotations["secretgen.carvel.dev/status"]), &observedStatus))
+		require.NoError(t, json.Unmarshal([]byte(placeholderSecret.Annotations["secretgen.carvel.dev/status"]), &observedStatus))
 		expectedStatus := map[string]interface{}{"conditions": []interface{}{map[string]interface{}{"status": "True", "type": "ReconcileSucceeded"}}, "secretNames": []interface{}{"test-source/test-secret"}}
 		assert.Equal(t, expectedStatus, observedStatus)
 
@@ -154,9 +154,9 @@ func Test_SecretReconciler_updatesStatus(t *testing.T) {
 
 		reload(t, &placeholderSecret, k8sClient)
 		assert.Equal(t, originalPlaceholderData, placeholderSecret.Data[".dockerconfigjson"])
-		assert.NotNil(t, placeholderSecret.ObjectMeta.Annotations["secretgen.carvel.dev/status"])
+		assert.NotNil(t, placeholderSecret.Annotations["secretgen.carvel.dev/status"])
 		var observedStatus map[string]interface{}
-		require.NoError(t, json.Unmarshal([]byte(placeholderSecret.ObjectMeta.Annotations["secretgen.carvel.dev/status"]), &observedStatus))
+		require.NoError(t, json.Unmarshal([]byte(placeholderSecret.Annotations["secretgen.carvel.dev/status"]), &observedStatus))
 		expectedStatus := map[string]interface{}{"conditions": []interface{}{map[string]interface{}{"message": "Expected secret to have type=corev1.SecretTypeDockerConfigJson, but did not", "status": "True", "type": "ReconcileFailed"}}}
 		assert.Equal(t, expectedStatus, observedStatus)
 
@@ -180,9 +180,9 @@ func Test_SecretReconciler_updatesStatus(t *testing.T) {
 
 		reload(t, &placeholderSecret, k8sClient)
 		assert.Equal(t, originalPlaceholderData, placeholderSecret.Data[".dockerconfigjson"])
-		assert.NotNil(t, placeholderSecret.ObjectMeta.Annotations["secretgen.carvel.dev/status"])
+		assert.NotNil(t, placeholderSecret.Annotations["secretgen.carvel.dev/status"])
 		var observedStatus map[string]interface{}
-		require.NoError(t, json.Unmarshal([]byte(placeholderSecret.ObjectMeta.Annotations["secretgen.carvel.dev/status"]), &observedStatus))
+		require.NoError(t, json.Unmarshal([]byte(placeholderSecret.Annotations["secretgen.carvel.dev/status"]), &observedStatus))
 		// Note placeholder secret Status has no "secretNames" key
 		expectedStatus := map[string]interface{}{"conditions": []interface{}{map[string]interface{}{"status": "True", "type": "ReconcileSucceeded"}}}
 		assert.Equal(t, expectedStatus, observedStatus)
@@ -211,7 +211,7 @@ func Test_SecretReconciler_updatesStatus(t *testing.T) {
 		reload(t, &placeholderSecret, k8sClient)
 
 		var observedStatus map[string]interface{}
-		require.NoError(t, json.Unmarshal([]byte(placeholderSecret.ObjectMeta.Annotations["secretgen.carvel.dev/status"]), &observedStatus))
+		require.NoError(t, json.Unmarshal([]byte(placeholderSecret.Annotations["secretgen.carvel.dev/status"]), &observedStatus))
 		expectedStatus := map[string]interface{}{"conditions": []interface{}{map[string]interface{}{"status": "True", "type": "ReconcileSucceeded"}}, "secretNames": []interface{}{"test-source/test-secret", "test-source/test-secret-2"}}
 		assert.Equal(t, expectedStatus, observedStatus)
 		expectedData := []byte(`{"auths":{"server":{"username":"correctUser","password":"correctPassword","auth":"correctAuth"},"server2":{"username":"correctUser2","password":"correctPassword2","auth":"correctAuth2"}}}`)
@@ -219,7 +219,7 @@ func Test_SecretReconciler_updatesStatus(t *testing.T) {
 	})
 }
 func placeholderReconcilers(objects ...runtime.Object) (secretExportReconciler *sharing.SecretExportReconciler, secretReconciler *sharing.SecretReconciler, k8sClient client.Client) {
-	k8sClient = fakeClient.NewFakeClient(objects...)
+	k8sClient = fakeClient.NewClientBuilder().WithRuntimeObjects(objects...).Build()
 	secretExports := sharing.NewSecretExportsWarmedUp(sharing.NewSecretExports(k8sClient, testLogr))
 	secretExportReconciler = sharing.NewSecretExportReconciler(k8sClient, secretExports, testLogr)
 	secretExports.WarmUpFunc = secretExportReconciler.WarmUp

--- a/pkg/sharing/secret_exports.go
+++ b/pkg/sharing/secret_exports.go
@@ -119,7 +119,14 @@ func (nm NamespacesMatcher) MatchNamespace(matcher SecretMatcher, log logr.Logge
 
 	jsonNsString, _ := json.Marshal(namespace)
 	var jsonNsObject interface{}
-	json.Unmarshal(jsonNsString, &jsonNsObject)
+	if uErr := json.Unmarshal(jsonNsString, &jsonNsObject); uErr != nil {
+		log.Error(uErr, "failed to unmarshal namespace JSON")
+		return false
+	}
+	if err != nil {
+		log.Error(err, fmt.Sprintf("failed to get namespace %s", nsName))
+		return false
+	}
 
 	if err != nil {
 		log.Error(err, fmt.Sprintf("failed to get namespace %s", nsName))
@@ -135,6 +142,9 @@ func (nm NamespacesMatcher) MatchNamespace(matcher SecretMatcher, log logr.Logge
 		}
 		var valueBuffer bytes.Buffer
 		err = jp.Execute(&valueBuffer, jsonNsObject)
+		if err != nil {
+			return false
+		}
 		value := valueBuffer.String()
 
 		switch s.Operator {

--- a/pkg/sharing/secret_exports.go
+++ b/pkg/sharing/secret_exports.go
@@ -143,7 +143,7 @@ func (nm NamespacesMatcher) MatchNamespace(matcher SecretMatcher, log logr.Logge
 		var valueBuffer bytes.Buffer
 		err = jp.Execute(&valueBuffer, jsonNsObject)
 		if err != nil {
-			return false
+			log.V(1).Info(fmt.Sprintf("jsonpath execution failed (key likely missing), using empty value: %v", err))
 		}
 		value := valueBuffer.String()
 

--- a/pkg/sharing/secret_exports_test.go
+++ b/pkg/sharing/secret_exports_test.go
@@ -45,7 +45,7 @@ func TestSecretExports(t *testing.T) {
 			},
 		}
 
-		k8sClient := fakeClient.NewFakeClient(secret1, secret2, export1, export2)
+		k8sClient := fakeClient.NewClientBuilder().WithRuntimeObjects(secret1, secret2, export1, export2).Build()
 		se := sharing.NewSecretExports(k8sClient, logr.Discard())
 
 		se.Export(export1, secret1)
@@ -256,7 +256,7 @@ func TestSecretExports(t *testing.T) {
 			Spec: sg2v1alpha1.SecretExportSpec{ToNamespace: "dst-ns", ToNamespaces: []string{"*"}},
 		}
 
-		k8sClient := fakeClient.NewFakeClient(secret1, secret2, export1, export2)
+		k8sClient := fakeClient.NewClientBuilder().WithRuntimeObjects(secret1, secret2, export1, export2).Build()
 		se := sharing.NewSecretExports(k8sClient, logr.Discard())
 
 		// Wildcard ns match in same namespace

--- a/pkg/sharing/secret_reconciler.go
+++ b/pkg/sharing/secret_reconciler.go
@@ -57,7 +57,7 @@ func (r *SecretReconciler) AttachWatches(controller controller.Controller) error
 		Log:           r.log,
 	})
 	if err != nil {
-		return fmt.Errorf("Watching secretExports: %s", err)
+		return fmt.Errorf("watching secretExports: %s", err)
 	}
 
 	// Watch namespaces partly so that we cache them because we migh be doing a lot of lookups

--- a/test/e2e/password_test.go
+++ b/test/e2e/password_test.go
@@ -167,15 +167,18 @@ spec:
 
 	name := "test-length-password-template"
 	cleanUp := func() {
-		kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{AllowError: true})
+		_, _ = kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{AllowError: true})
 	}
 
 	cleanUp()
 	defer cleanUp()
 
 	logger.Section("Deploy", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
+		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
 			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+		if err != nil {
+			t.Fatalf("Deploy failed: %v", err)
+		}
 	})
 
 	logger.Section("Check secret", func() {
@@ -232,15 +235,18 @@ spec:
 
 	name := "test-complex-password-template"
 	cleanUp := func() {
-		kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{AllowError: true})
+		_, _ = kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{AllowError: true})
 	}
 
 	cleanUp()
 	defer cleanUp()
 
 	logger.Section("Deploy", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
+		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
 			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+		if err != nil {
+			t.Fatalf("Deploy failed: %v", err)
+		}
 	})
 
 	logger.Section("Check secret", func() {
@@ -294,15 +300,18 @@ spec:
 
 	name := "test-symbol-password-template"
 	cleanUp := func() {
-		kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{AllowError: true})
+		_, _ = kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{AllowError: true})
 	}
 
 	cleanUp()
 	defer cleanUp()
 
 	logger.Section("Deploy", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
+		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
 			RunOpts{IntoNs: true, StdinReader: strings.NewReader(yaml1)})
+		if err != nil {
+			t.Fatalf("Deploy failed: %v", err)
+		}
 	})
 
 	logger.Section("Check secret", func() {

--- a/test/e2e/placeholder_secrets_multi_case_test.go
+++ b/test/e2e/placeholder_secrets_multi_case_test.go
@@ -360,15 +360,18 @@ data:
 
 	name := "test-placeholder-export-successful"
 	cleanUp := func() {
-		kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{AllowError: true})
+		_, _ = kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{AllowError: true})
 	}
 
 	cleanUp()
 	defer cleanUp()
 
 	logger.Section("Initial Deploy", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
+		_, err := kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
 			RunOpts{StdinReader: strings.NewReader(yaml1)})
+		if err != nil {
+			t.Fatalf("Deploy failed: %v", err)
+		}
 	})
 
 	// both ns have the exclusion annotation, but sg-test3 is also named explicitly.

--- a/test/e2e/secret_exports_test.go
+++ b/test/e2e/secret_exports_test.go
@@ -416,7 +416,7 @@ stringData:
 
 	logger.Section("Delete export to see exported secrets deleted", func() {
 		for _, secretName := range []string{"secret", "secret-test5", "secret-test6", "secret-test7", "secret-test8"} {
-			kubectl.RunWithOpts([]string{"delete", "secretexport.secretgen.carvel.dev", secretName, "-n", "sg-test1"},
+			_, _ = kubectl.RunWithOpts([]string{"delete", "secretexport.secretgen.carvel.dev", secretName, "-n", "sg-test1"},
 				RunOpts{NoNamespace: true})
 		}
 

--- a/test/e2e/secret_template_test.go
+++ b/test/e2e/secret_template_test.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"testing"
 
+	sgv1alpha1 "carvel.dev/secretgen-controller/pkg/apis/secretgen/v1alpha1"
+	sg2v1alpha1 "carvel.dev/secretgen-controller/pkg/apis/secretgen2/v1alpha1"
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	sgv1alpha1 "carvel.dev/secretgen-controller/pkg/apis/secretgen/v1alpha1"
-	sg2v1alpha1 "carvel.dev/secretgen-controller/pkg/apis/secretgen2/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -72,15 +72,15 @@ stringData:
 
 	name := "test-secrettemplate-full-lifecycle"
 	cleanUp := func() {
-		kapp.RunWithOpts([]string{"delete", "-a", name + "-template"}, RunOpts{AllowError: true})
-		kapp.RunWithOpts([]string{"delete", "-a", name + "-inputs"}, RunOpts{AllowError: true})
+		_, _ = kapp.RunWithOpts([]string{"delete", "-a", name + "-template"}, RunOpts{AllowError: true})
+		_, _ = kapp.RunWithOpts([]string{"delete", "-a", name + "-inputs"}, RunOpts{AllowError: true})
 	}
 
 	cleanUp()
 	defer cleanUp()
 
 	logger.Section("Create Template", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name + "-template"},
+		_, _ = kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name + "-template"},
 			RunOpts{StdinReader: strings.NewReader(testSecretTemplateYaml)})
 	})
 
@@ -100,7 +100,7 @@ stringData:
 	})
 
 	logger.Section("Create Input Resources", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name + "-inputs"},
+		_, _ = kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name + "-inputs"},
 			RunOpts{StdinReader: strings.NewReader(testInputResourcesYaml)})
 	})
 
@@ -118,7 +118,7 @@ stringData:
 	})
 
 	logger.Section("Delete Input Resources", func() {
-		kapp.RunWithOpts([]string{"delete", "-a", name + "-inputs"}, RunOpts{AllowError: true})
+		_, _ = kapp.RunWithOpts([]string{"delete", "-a", name + "-inputs"}, RunOpts{AllowError: true})
 	})
 
 	logger.Section("Check template has ReconcileFailed but secret remains", func() {
@@ -223,14 +223,14 @@ spec:
 
 	name := "test-secrettemplate-service-account-successful"
 	cleanUp := func() {
-		kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{AllowError: true})
+		_, _ = kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{AllowError: true})
 	}
 
 	cleanUp()
 	defer cleanUp()
 
 	logger.Section("Deploy", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
+		_, _ = kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
 			RunOpts{StdinReader: strings.NewReader(testYaml)})
 	})
 
@@ -323,14 +323,14 @@ spec:
 
 	name := "test-secrettemplate-service-account-failure"
 	cleanUp := func() {
-		kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{AllowError: true})
+		_, _ = kapp.RunWithOpts([]string{"delete", "-a", name}, RunOpts{AllowError: true})
 	}
 
 	cleanUp()
 	defer cleanUp()
 
 	logger.Section("Deploy", func() {
-		kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
+		_, _ = kapp.RunWithOpts([]string{"deploy", "-f", "-", "-a", name},
 			RunOpts{StdinReader: strings.NewReader(testYaml)})
 	})
 
@@ -354,7 +354,7 @@ func waitForSecretTemplate(t *testing.T, kubectl Kubectl, name string, condition
 	waitArgs := []string{"wait", fmt.Sprintf("--for=condition=%s=%s", condition.Type, condition.Status), "secrettemplate", name}
 	getArgs := []string{"get", "secrettemplate", name, "-o", "yaml"}
 
-	kubectl.RunWithOpts(waitArgs, RunOpts{AllowError: true})
+	_, _ = kubectl.RunWithOpts(waitArgs, RunOpts{AllowError: true})
 
 	out, err := kubectl.RunWithOpts(getArgs, RunOpts{AllowError: true})
 	if err == nil {


### PR DESCRIPTION
Bumping golang to 1.25.5 to fix the following CVEs:

```
┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-61729 │ HIGH     │ fixed  │ v1.25.4           │ 1.24.11, 1.25.5 │ crypto/x509: Excessive resource consumption when printing   │
│         │                │          │        │                   │                 │ error string for host certificate validation...             │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-61729                  │
│         ├────────────────┼──────────┤        │                   │                 ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2025-61727 │ MEDIUM   │        │                   │                 │ golang: crypto/x509: excluded subdomain constraint does not │
│         │                │          │        │                   │                 │ restrict wildcard SANs                                      │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-61727                  │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴─────────────────────────────────────────────────────────────┘
```