### PR TITLE
Fix panics under GODEBUG=fips140=only in SSHKey/Certificate generation

### DIFF
--- a/pkg/generator/certificate_reconciler.go
+++ b/pkg/generator/certificate_reconciler.go
@@ -5,6 +5,7 @@ package generator
 
 import (
 	"context"
+	"crypto/fips140"
 	"fmt"
 
 	sgv1alpha1 "carvel.dev/secretgen-controller/pkg/apis/secretgen/v1alpha1"
@@ -185,7 +186,15 @@ func (r *CertificateReconciler) generate(ctx context.Context, params certParams,
 
 	gen := cfgtypes.NewCertificateGenerator(singleCertLoader{caCertSecret})
 
-	certVal, err := gen.Generate(params)
+	// cfgtypes.CertificateGenerator.Generate uses crypto/sha1 to derive the certificate's
+	// SubjectKeyId (RFC 5280 4.2.1.2, method (1)): a non-cryptographic key identifier used
+	// for chain-building/lookup, not for signing or trust decisions. WithoutEnforcement
+	// scopes the FIPS 140-3 "only" exemption to just this call, so it has no effect when
+	// strict enforcement isn't active.
+	var certVal interface{}
+	fips140.WithoutEnforcement(func() {
+		certVal, err = gen.Generate(params)
+	})
 	if err != nil {
 		return cfgtypes.CertResponse{}, err
 	}

--- a/pkg/generator/fips140_internal_test.go
+++ b/pkg/generator/fips140_internal_test.go
@@ -1,0 +1,57 @@
+// Copyright 2024 The Carvel Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package generator
+
+import (
+	"context"
+	"crypto/fips140"
+	"testing"
+
+	sgv1alpha1 "carvel.dev/secretgen-controller/pkg/apis/secretgen/v1alpha1"
+)
+
+// These tests only exercise anything meaningful when run with
+// GOFIPS140=v1.0.0 GODEBUG=fips140=only, which enables strict FIPS 140-3
+// enforcement (crypto/fips140.Enforced() reports it at runtime). Without
+// that, they degrade to a skip so they don't add noise to a normal `go test
+// ./...` run.
+
+func TestSSHKeyReconciler_GenerateUnderFIPS140Only(t *testing.T) {
+	if !fips140.Enforced() {
+		t.Skip("run with GOFIPS140=v1.0.0 GODEBUG=fips140=only to exercise strict FIPS 140-3 enforcement")
+	}
+
+	r := &SSHKeyReconciler{}
+
+	sshKey, err := r.generate(&sgv1alpha1.SSHKey{})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if sshKey.PrivateKey == "" || sshKey.PublicKey == "" || sshKey.PublicKeyFingerprint == "" {
+		t.Fatalf("generate returned incomplete SSHKey: %+v", sshKey)
+	}
+}
+
+func TestCertificateReconciler_GenerateUnderFIPS140Only(t *testing.T) {
+	if !fips140.Enforced() {
+		t.Skip("run with GOFIPS140=v1.0.0 GODEBUG=fips140=only to exercise strict FIPS 140-3 enforcement")
+	}
+
+	r := &CertificateReconciler{}
+	cert := &sgv1alpha1.Certificate{
+		Spec: sgv1alpha1.CertificateSpec{
+			CommonName: "test-ca",
+			IsCA:       true,
+		},
+	}
+	params := newCertParams(cert)
+
+	certResp, err := r.generate(context.Background(), params, cert)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if certResp.Certificate == "" || certResp.PrivateKey == "" {
+		t.Fatalf("generate returned incomplete CertResponse: %+v", certResp)
+	}
+}

--- a/pkg/generator/ssh_key_reconciler.go
+++ b/pkg/generator/ssh_key_reconciler.go
@@ -5,6 +5,7 @@ package generator
 
 import (
 	"context"
+	"crypto/fips140"
 	"fmt"
 
 	sgv1alpha1 "carvel.dev/secretgen-controller/pkg/apis/secretgen/v1alpha1"
@@ -122,7 +123,15 @@ func (r *SSHKeyReconciler) generate(sshKey *sgv1alpha1.SSHKey) (cfgtypes.SSHKey,
 	gen := cfgtypes.NewSSHKeyGenerator()
 
 	// TODO allow type and number of bits?
-	sshKeyVal, err := gen.Generate(nil)
+	// cfgtypes.SSHKeyGenerator.Generate uses crypto/md5 to compute PublicKeyFingerprint,
+	// a display-only identifier (same convention as `ssh-keygen -l -E md5`), not a
+	// cryptographic operation. WithoutEnforcement scopes the FIPS 140-3 "only" exemption
+	// to just this call, so it has no effect when strict enforcement isn't active.
+	var sshKeyVal interface{}
+	var err error
+	fips140.WithoutEnforcement(func() {
+		sshKeyVal, err = gen.Generate(nil)
+	})
 	if err != nil {
 		return cfgtypes.SSHKey{}, err
 	}


### PR DESCRIPTION
### **Problem**
When running under Go's native FIPS 140-3 "only" enforcement mode (`GOFIPS140=v1.0.0` + `GODEBUG=fips140=only`), reconciling any `SSHKey` or `Certificate` resource panics unconditionally:
- `SSHKeyGenerator.fingerprintMD5` (`github.com/cloudfoundry/config-server`, `vendor/.../ssh_key_generator.go:72`) uses `crypto/md5` to compute the SSH public key fingerprint exposed as `SSHKey.PublicKeyFingerprint` — the same convention as `ssh-keygen -l -E md5`.
- `CertificateGenerator.bigIntHash`(`vendor/.../certificate_generator.go:66`) uses `crypto/sha1` to derive the X.509 `SubjectKeyId` per RFC 5280 §4.2.1.2, method (1).

Neither use is a cryptographic operation in the security sense — they're non-forgeability-sensitive identifiers, not signatures or authentication. But Go's `fips140=only` mode blocks the primitive itself regardless of call-site intent, so both `md5.Sum`/`sha1.Sum` calls panic as soon as they execute, breaking every `SSHKey` and `Certificate` reconcile under strict FIPS enforcement.

### **Fix**
Rather than touching the vendored `cloudfoundry/config-server` library, this wraps the two call sites — in this project's own `pkg/generator` code — with `crypto/fips140.WithoutEnforcement` (added in Go 1.26):
- `pkg/generator/ssh_key_reconciler.go`: wrap `gen.Generate(nil)` in `SSHKeyReconciler.generate`
- `pkg/generator/certificate_reconciler.g`o: wrap `gen.Generate(params)` in `CertificateReconciler.generate`

`WithoutEnforcement` scopes the FIPS 140-3 "only" exemption to just the wrapped callback, and per its own documented semantics (and Go stdlib source) is a no-op whenever strict `fips140=only` enforcement isn't active. So this has no effect on non-FIPS builds, or on `GODEBUG=fips140=on` — confirmed both by reading `crypto/fips140`'s implementation and by empirical testing (identical behavior wrapped vs. unwrapped in both non-FIPS and `fips140=on `modes; only `fips140=only` diverges, which is exactly the mode this fixes).

### **Testing**

- Added `pkg/generator/fips140_internal_test.go` with two tests exercising `SSHKeyReconciler.generate` and `CertificateReconciler.generate` directly, gated on `fips140.Enforced()`:
  - Skip as a no-op under normal test runs (no FIPS enforcement active).
  - Pass under `GOFIPS140=v1.0.0 GODEBUG=fips140=only`, where they previously would have panicked.
- Ran the existing `pkg/generator`, `pkg/expansion`, `pkg/satoken`, `pkg/sharing`, `pkg/tracker` test suites both at baseline and under `GOFIPS140=v1.0.0 GODEBUG=fips140=only` — all pass in both configurations.
- Verified via a standalone reproduction that wrapped vs. unwrapped `md5/sha1` calls behave identically under no-FIPS and `fips140=on`, and diverge (panic vs. no panic) only under `fips140=only`.